### PR TITLE
[ENG-5795] Handle `flags` and `config` properties in profiles YAML

### DIFF
--- a/dbt_profiles_schema.json
+++ b/dbt_profiles_schema.json
@@ -5,7 +5,10 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
     "patternProperties": {
-        "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+        "^(flags|config)$": {
+            "type": "object"
+        },
+        "^(?!flags$|config$)[a-zA-Z_][a-zA-Z0-9_]*$": {
             "description": "The name of the profile. Contains all the details required to connect to your data warehouse. Make sure that this is the same name as the profile indicated in your dbt_project.yml file.",
             "type": "object",
             "properties": {


### PR DESCRIPTION
See:

- https://docs.getdbt.com/reference/global-configs/about-global-configs
- https://github.com/dbt-labs/dbt-core/issues/9183

`flags` and `config` can be included in these YAML files. `config` is being deprecated in favour of `flags`, but is still supported.